### PR TITLE
fix: :bug: Fix getting fallback / default value

### DIFF
--- a/app/View/Composers/Partials/Archive.php
+++ b/app/View/Composers/Partials/Archive.php
@@ -63,7 +63,7 @@ class Archive extends Composer
         $config = stage_get_fallback($chosen_key, false, true);
 
         // No setting, get from default
-        return !isset($config) ? stage_get_default($default_key, true) : $config;
+        return !$config ? stage_get_default($default_key, true) : $config;
     }
 
     /**


### PR DESCRIPTION

The `!isset($config)` will always return false, since $config is defined. Therefor this method wouldn't return the default value for undefined CPTs.

Without this fix, navigating to an archive url of an undefined CPT would throw an exception ("View [partials.archive.grids.] not found.").